### PR TITLE
chore: update README for Hugo v0.120.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Call `wtfhugo` in your site's `<head>`:
 And that's it. You can call it conditionally, of course:
 
 ```
-{{- if and (.Param "WTFHugo") site.IsServer -}}
+{{- if and (.Param "WTFHugo") hugo.IsServer -}}
   {{- partial "wtfhugo.html" . }}
 {{- end -}}
 ```


### PR DESCRIPTION
Hello, Jeremy.

First, thanks a lot for maintaining this. I find it very useful in development.

---

### PR Description:

This PR replaces `.Site.IsServer` with `hugo.IsServer` in the README. Otherwise, one is likely to encounter the following error:

```
ERROR: deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo v0.135.0. Please use hugo.IsServer instead.
```

### Summary:
- Replaced `.Site.IsServer` with `hugo.IsServer`

This update will prevent future compatibility issues as `.Site.IsServer` is being deprecated.


### Additional note

Request you to update the same here as well: https://wtfhugo.i40west.io/ .
