### PR TITLE
chore: enforce a minimum required Hugo version.

### DIFF
--- a/layouts/partials/wtfhugo.html
+++ b/layouts/partials/wtfhugo.html
@@ -1,3 +1,9 @@
+{{- /* Enforce minimum required Hugo version. */}}
+{{- $minHugoVersion := "0.123.0" }}
+{{- if lt hugo.Version $minHugoVersion }}
+  {{- errorf "WTFHugo requires Hugo v%s or later. Please upgrade Hugo to v%s or higher to use WTFHugo." $minHugoVersion $minHugoVersion }}
+{{- end -}}
+
 {{- $wtfpage := partial "wtf.html" .Page }}
 {{- $wtfsite := partial "wtf.html" .Site }}
 <script id="wtfhugo" type="application/json">


### PR DESCRIPTION
### PR Description:

This PR enforces a minimum required Hugo version for the project. Specifically, it introduces a check to ensure that Hugo v0.123.0 or later is being used. If an earlier version is detected, the following error will be triggered:

```
WTFHugo requires Hugo v0.123.0 or later. Please upgrade Hugo to v0.123.0 or higher to use WTFHugo.
```

### Summary:
- Added a version check using `hugo.Version` to ensure compatibility with Hugo v0.123.0 or later.
- Implemented an error message for users attempting to run the project using Hugo version <  v0.123.0.

--- 

Let me know if you need any changes!