### PR TITLE
fix: ERROR deprecated: .Site.Social was deprecated in Hugo v0.124.0

### DIFF
--- a/layouts/partials/wtf.html
+++ b/layouts/partials/wtf.html
@@ -82,7 +82,7 @@
 
     {{- if (or $typeIsSiteWrapper $typeIsSiteInfo) }} <!-- https://github.com/gohugoio/hugo/blob/master/hugolib/site.go -->
         {{- $varNames   = (slice "Title" "Author" "Social" "Lastmod" "Copyright" "LanguageCode" "Language.Lang" "BuildDrafts" "Params" "Menus") }}
-        {{- $varSymbols = (slice .Title  .Author  .Social  .Lastmod  .Copyright  .LanguageCode  .Language.Lang  .BuildDrafts  .Params  .Menus ) }}
+        {{- $varSymbols = (slice .Title  .Author  .Params.Social  .Lastmod  .Copyright  .LanguageCode  .Language.Lang  .BuildDrafts  .Params  .Menus ) }}
 
     {{- else if $typeIsGitInfo }} <!-- https://github.com/bep/gitmap/blob/master/gitmap.go -->
         {{- $varNames   = (slice "Hash" "AbbreviatedHash" "Subject" "AuthorName" "AuthorEmail" "AuthorDate") }}


### PR DESCRIPTION
## Fix .Site.Social error
- This PR fixes the following error 
    ```
    ERROR deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.141.0. Implement taxonomy 'social' or use .Site.Params.Social instead. 
    ```
- This PR implements `.Site.Params.Social`